### PR TITLE
Fix duplicate CLI page, restore seed node data

### DIFF
--- a/docs/run/guided-setup/installing-node.md
+++ b/docs/run/guided-setup/installing-node.md
@@ -146,7 +146,18 @@ The config file is created from the input. It will be used during the installati
 
 
 
-**Mainnet Seed Nodes**
+
+<details>
+<summary><strong>Mainnet Seed Nodes</strong></summary>
+
+```
+radix://node_rdx1qf2x63qx4jdaxj83kkw2yytehvvmu6r2xll5gcp6c9rancmrfsgfw0vnc65@babylon-mainnet-eu-west-1-node0.radixdlt.com
+radix://node_rdx1qgxn3eeldj33kd98ha6wkjgk4k77z6xm0dv7mwnrkefknjcqsvhuu4gc609@babylon-mainnet-ap-southeast-2-node0.radixdlt.com
+radix://node_rdx1qwrrnhzfu99fg3yqgk3ut9vev2pdssv7hxhff80msjmmcj968487uugc0t2@babylon-mainnet-ap-south-1-node0.radixdlt.com
+radix://node_rdx1q0gnmwv0fmcp7ecq0znff7yzrt7ggwrp47sa9pssgyvrnl75tvxmvj78u7t@babylon-mainnet-us-east-1-node0.radixdlt.com
+```
+
+</details>
 
 
 
@@ -159,12 +170,17 @@ The config file is created from the input. It will be used during the installati
 
 
 
+<details>
+<summary><strong>Stokenet Seed Nodes</strong></summary>
 
+```
+radix://node_tdx_2_1qv89yg0la2jt429vqp8sxtpg95hj637gards67gpgqy2vuvwe4s5ss0va2y@babylon-stokenet-ap-south-1-node0.radixdlt.com
+radix://node_tdx_2_1qvtd9ffdhxyg7meqggr2ezsdfgjre5aqs6jwk5amdhjg86xhurgn5c79t9t@babylon-stokenet-ap-southeast-2-node0.radixdlt.com
+radix://node_tdx_2_1qwfh2nn0zx8cut5fqfz6n7pau2f7vdyl89mypldnn4fwlhaeg2tvunp8s8h@babylon-stokenet-eu-west-1-node0.radixdlt.com
+radix://node_tdx_2_1qwz237kqdpct5l3yjhmna66uxja2ymrf3x6hh528ng3gtvnwndtn5rsrad4@babylon-stokenet-us-east-1-node1.radixdlt.com
+```
 
-**Stokenet Seed Nodes**
-
-
-
+</details>
 
 
 

--- a/docs/run/guided-setup/installing-node.md
+++ b/docs/run/guided-setup/installing-node.md
@@ -151,10 +151,8 @@ The config file is created from the input. It will be used during the installati
 <summary><strong>Mainnet Seed Nodes</strong></summary>
 
 ```
-radix://node_rdx1qf2x63qx4jdaxj83kkw2yytehvvmu6r2xll5gcp6c9rancmrfsgfw0vnc65@babylon-mainnet-eu-west-1-node0.radixdlt.com
-radix://node_rdx1qgxn3eeldj33kd98ha6wkjgk4k77z6xm0dv7mwnrkefknjcqsvhuu4gc609@babylon-mainnet-ap-southeast-2-node0.radixdlt.com
-radix://node_rdx1qwrrnhzfu99fg3yqgk3ut9vev2pdssv7hxhff80msjmmcj968487uugc0t2@babylon-mainnet-ap-south-1-node0.radixdlt.com
-radix://node_rdx1q0gnmwv0fmcp7ecq0znff7yzrt7ggwrp47sa9pssgyvrnl75tvxmvj78u7t@babylon-mainnet-us-east-1-node0.radixdlt.com
+radix://node_rdx1qf2x63qx4jdaxj83kkw2yytehvvmu6r2xll5gcp6c9rancmrfsgfw0vnc65@babylon-mainnet-eu-west-1-node1.radixdlt.com
+radix://node_rdx1qgxn3eeldj33kd98ha6wkjgk4k77z6xm0dv7mwnrkefknjcqsvhuu4gc609@babylon-mainnet-ap-south-1-node0.radixdlt.com
 ```
 
 </details>

--- a/docs/run/guided-setup/installing-the-babylonnode-cli.md
+++ b/docs/run/guided-setup/installing-the-babylonnode-cli.md
@@ -1,8 +1,0 @@
----
-title: "Installing the BabylonNode CLI"
-slug: /installing-the-babylonnode-cli
----
-
-# Installing the BabylonNode CLI
-
-todo

--- a/docs/run/running-a-node.md
+++ b/docs/run/running-a-node.md
@@ -115,7 +115,7 @@ Below is a matrix of all productionised setup modes that have been covered in th
 Before we move on, it's a good time to introduce our node runner helper application: the \`babylonnode\` CLI.  
 It is not required to use it, but it can greatly reduce the effort of setting up a node, and thus we recommend doing so. It supports both of our recommended setup modes, that is: SystemD and Docker.
 
-### Next (Optional, but recommended): [Installing the babylonnode CLI](guided-setup/installing-the-babylonnode-cli.md)
+### Next (Optional, but recommended): [Installing the babylonnode CLI](guided-setup/installing-cli.md)
 
 ### Next next (or just "Next" if skipping the CLI): [Basic node setup](node-setup/basic-node-setup.md)
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -476,7 +476,7 @@ const sidebars = {
                   "items": [
                     {
                       "type": "doc",
-                      "id": "run/guided-setup/installing-the-babylonnode-cli",
+                      "id": "run/guided-setup/installing-cli",
                       "label": "Installing the babylonnode CLI"
                     },
                     {


### PR DESCRIPTION
## Summary

- Remove placeholder `installing-the-babylonnode-cli.md` that just said "todo" — a migration artifact
- Point sidebar and `running-a-node.md` link to the real `installing-cli.md` with actual content
- Restore missing Mainnet and Stokenet seed node addresses in the guided setup page using `<details>` accordion tags

The seed node data was lost during the gitbook migration (it was in an expandable widget that exported as empty). Data recovered from the Docker/systemd setup pages in the gitbook source.

## Test plan

- [ ] https://docs.radixdlt.com/docs/node-setup-guided-installing-cli — shows real content (not "todo")
- [ ] Sidebar under Run > Guided Setup shows "Installing the babylonnode CLI" linking to the above page
- [ ] https://docs.radixdlt.com/docs/running-a-node — "Installing the babylonnode CLI" link works
- [ ] https://docs.radixdlt.com/docs/node-setup-guided-installing-node — Mainnet and Stokenet seed nodes show as expandable accordions with seed node addresses